### PR TITLE
Fix database migrations

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+lib/seeds/mysc-seed.dump filter=lfs diff=lfs merge=lfs -text

--- a/bin/setup
+++ b/bin/setup
@@ -19,8 +19,8 @@ Dir.chdir APP_ROOT do
   puts "\n== Creating database =="
   system 'bin/rails db:create'
 
-  puts "\n== Import SQL Seed Data =="
-  system 'bin/rails import:seed'
+  # puts "\n== Import SQL Seed Data =="
+  # system 'bin/rails import:seed'
 
   puts "\n== Preparing database =="
   system 'bin/rails db:migrate'

--- a/db/migrate/20170125020724_create_schools.rb
+++ b/db/migrate/20170125020724_create_schools.rb
@@ -1,0 +1,33 @@
+class CreateSchools < ActiveRecord::Migration[5.0]
+  def change
+    create_table "schools", force: :cascade do |t|
+      t.string   "name",             limit: 200,                                    null: false
+      t.string   "slug",             limit: 200
+      t.string   "schid",            limit: 8
+      t.string   "address",          limit: 150
+      t.string   "town_mail",        limit: 25
+      t.string   "town",             limit: 25
+      t.string   "state",            limit: 2
+      t.string   "zip",              limit: 10
+      t.string   "principal",        limit: 50
+      t.string   "phone",            limit: 15
+      t.string   "fax",              limit: 15
+      t.string   "grades",           limit: 70
+      t.string   "schl_type",        limit: 3
+      t.integer  "district_id"
+      t.text     "survey_incentive"
+      t.boolean  "survey_active"
+      t.geometry "geometry",         limit: {:srid=>0, :type=>"point"},             null: false
+      t.geometry "shed_05",          limit: {:srid=>26986, :type=>"multi_polygon"}
+      t.geometry "shed_10",          limit: {:srid=>26986, :type=>"multi_polygon"}
+      t.geometry "shed_15",          limit: {:srid=>26986, :type=>"multi_polygon"}
+      t.geometry "shed_20",          limit: {:srid=>26986, :type=>"multi_polygon"}
+      t.integer  "muni_id"
+      t.index "slug varchar_pattern_ops", name: "survey_school_slug_like", using: :btree
+      t.index ["district_id"], name: "survey_school_districtid_id", using: :btree
+      t.index ["geometry"], name: "survey_school_geometry_id", using: :gist
+      t.index ["schid"], name: "survey_school_schid_key", unique: true, using: :btree
+      t.index ["slug"], name: "survey_school_slug", using: :btree
+    end
+  end
+end

--- a/db/migrate/20170607200956_remove_null_value_constrain_from_schools.rb
+++ b/db/migrate/20170607200956_remove_null_value_constrain_from_schools.rb
@@ -1,5 +1,0 @@
-class RemoveNullValueConstrainFromSchools < ActiveRecord::Migration[5.0]
-  def change
-    change_column :schools, :survey_active, :boolean, :null => true
-  end
-end

--- a/db/migrate/20170607202843_remove_constraint_from_schools.rb
+++ b/db/migrate/20170607202843_remove_constraint_from_schools.rb
@@ -1,9 +1,0 @@
-class RemoveConstraintFromSchools < ActiveRecord::Migration[5.0]
-  def self.up
-    execute "ALTER TABLE schools DROP CONSTRAINT enforce_srid_geometry"
-  end
-
-  def self.down
-    execute "ALTER TABLE schools ADD CONSTRAINT enforce_srid_geometry CHECK (st_srid(geometry) = 26986)"
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 20170608173707) do
     t.datetime "updated_at",                                              null: false
   end
 
-  create_table "schools", id: :integer, default: -> { "nextval('survey_school_id_seq'::regclass)" }, force: :cascade do |t|
+  create_table "schools", force: :cascade do |t|
     t.string   "name",             limit: 200,                                    null: false
     t.string   "slug",             limit: 200
     t.string   "schid",            limit: 8

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,3 +6,9 @@
 #   cities = City.create([{ name: 'Chicago' }, { name: 'Copenhagen' }])
 #   Mayor.create(name: 'Emanuel', city: cities.first)
 User.create({ email: 'admin@user.org', password: 'password', is_admin: true })
+
+if Rails.env.development?
+  sh "pg_restore -a -O -d #{Rails.configuration.database_configuration[Rails.env]['database']} -t schools -t survey_network_bike -t survey_network_walk lib/seeds/mysc-development.dump"
+else
+  sh "pg_restore -a -O -U #{Rails.configuration.database_configuration[Rails.env]['username']} -d #{Rails.configuration.database_configuration[Rails.env]['database']} -t schools -t survey_network_bike -t survey_network_walk lib/seeds/mysc-development.dump"
+end

--- a/lib/seeds/mysc-seed.dump
+++ b/lib/seeds/mysc-seed.dump
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5934073b7d731652c94df59e5be324d5a7c6526141bf0fc01daa7268e9ea51e2
+size 650983051

--- a/lib/seeds/schools.sql
+++ b/lib/seeds/schools.sql
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6f7c4a26f29460feda1a9ef8d982bd1212df361078feaffb77e826959128cc8e
-size 645493359

--- a/lib/seeds/survey_network_bike.sql
+++ b/lib/seeds/survey_network_bike.sql
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:90421a2a36cbe08444c26858244f55d9fd47328ac9ceec6e41a7398b73f7bd9a
-size 819751926

--- a/lib/seeds/survey_network_walk.sql
+++ b/lib/seeds/survey_network_walk.sql
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dbf215987e34c4621387859859f746ae90bd11ccc3c9170ccd3c1712bdd869eb
-size 809620793


### PR DESCRIPTION
This commit fixes the databse migration issues by doing the following:

* Updates schema to not rely upon the old index of schools (previously survey_schools)
* Uses the postgres “dump” format to store and restore the seed data saving us a few GB of storage
* Removes migrations that were dependent upon database schema information coming from the SQL files that were previously being imported
* Remove the previously imported SQL files that we no longer import from
* Use Git LFS for the .dump file

## Description

## Reviewer Note: Did I run `rails test` and 100% passing tests before merging?
