### PR TITLE
Resolve #165 Survey Search Crash

### DIFF
--- a/app/dashboards/survey_dashboard.rb
+++ b/app/dashboards/survey_dashboard.rb
@@ -10,7 +10,6 @@ class SurveyDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     survey_responses: Field::HasMany,
     school: Field::BelongsTo,
-    school_name: Field::String,
     id: Field::Number,
     begin: Field::DateTime,
     end: Field::DateTime,
@@ -26,7 +25,6 @@ class SurveyDashboard < Administrate::BaseDashboard
   COLLECTION_ATTRIBUTES = [
     :survey_responses,
     :school,
-    :school_name,
     :begin,
     :end
   ].freeze


### PR DESCRIPTION
* The school_name property being included in the survey dashboard was causing the app to crash. Administrate automatically populates the name of the school when we have a belongs_to association, so we can simply remove that property and the search will work properly.
