### PR TITLE
Update Setup Script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -26,6 +26,9 @@ Dir.chdir APP_ROOT do
   puts "\n== Import SQL Seed Data =="
   system 'bin/rails db:seed'
 
+  puts "\n== Reset ID Sequences =="
+  system 'bin/rails database:correct_seq_id'
+
   puts "\n== Removing old logs and tempfiles =="
   system 'bin/rails log:clear tmp:clear'
 

--- a/bin/setup
+++ b/bin/setup
@@ -19,17 +19,12 @@ Dir.chdir APP_ROOT do
   puts "\n== Creating database =="
   system 'bin/rails db:create'
 
-  # puts "\n== Import SQL Seed Data =="
-  # system 'bin/rails import:seed'
-
   puts "\n== Preparing database =="
   system 'bin/rails db:migrate'
   system 'bin/rails db:migrate RAILS_ENV=test'
 
-  puts "\n== Import CSV Seed Data =="
+  puts "\n== Import SQL Seed Data =="
   system 'bin/rails db:seed'
-  system 'bin/rails import:districts'
-  system 'bin/rails import:districts RAILS_ENV=test'
 
   puts "\n== Removing old logs and tempfiles =="
   system 'bin/rails log:clear tmp:clear'


### PR DESCRIPTION
We need to update this so a developer setting up MySchoolCommute from scratch does not get errors when the import process for districts fails. This commit updates the setup script to no longer import seed data that is already imported in the db:seed process.
