### PR TITLE
Fix Google Maps API for distance field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bower_components/
 node_modules/
 .DS_Store
 public/reports/*.pdf
+lib/external/school-map/build
 
 .env
 .ssh

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -63,19 +63,25 @@ class SurveyResponse < ActiveRecord::Base
       dest_lat, dest_lng = lat_lng(school.wgs84_lat, school.wgs84_lng)
 
       # this needs to be refactored. this is lifted from the old app.
-      url = URI("http://maps.googleapis.com/maps/api/directions/json?sensor=false&origin=#{origin_lat},#{origin_lng}&destination=#{dest_lat},#{dest_lng}")
-      http = Net::HTTP.new(url.host, url.port)
+      url = URI("https://maps.googleapis.com/maps/api/directions/json?sensor=false&origin=#{origin_lat},#{origin_lng}&destination=#{dest_lat},#{dest_lng}&key=#{Rails.application.secrets.maps_api_key}")
 
       request = Net::HTTP::Get.new(url)
       request["content-type"] = 'application/json'
       request["cache-control"] = 'no-cache'
+
+      http = Net::HTTP.new(url.host, url.port)
+      http.use_ssl = true
       response = http.request(request)
 
       begin
         meters = JSON.parse(response.read_body)['routes'][0]['legs'][0]['distance']['value']
         miles = meters * 0.000621371
       rescue Exception => e
-        Raven.capture_exception(e, :extra => { 'lat': origin_lat, 'lng': origin_lng })
+        Raven.capture_exception(e, :extra => {
+          'lat': origin_lat,
+          'lng': origin_lng,
+          'req_url': url,
+        })
         miles = nil
       end
 

--- a/app/models/survey_response.rb
+++ b/app/models/survey_response.rb
@@ -63,7 +63,15 @@ class SurveyResponse < ActiveRecord::Base
       dest_lat, dest_lng = lat_lng(school.wgs84_lat, school.wgs84_lng)
 
       # this needs to be refactored. this is lifted from the old app.
-      url = URI("https://maps.googleapis.com/maps/api/directions/json?sensor=false&origin=#{origin_lat},#{origin_lng}&destination=#{dest_lat},#{dest_lng}&key=#{Rails.application.secrets.maps_api_key}")
+      google_api_url = "https://maps.googleapis.com/maps/api/directions/json?" +
+                      [
+                        "sensor=false",
+                        "origin=#{origin_lat},#{origin_lng}",
+                        "destination=#{dest_lat},#{dest_lng}",
+                        "key=#{Rails.application.secrets.maps_api_key}",
+                      ].join('&')
+
+      url = URI(google_api_url)
 
       request = Net::HTTP::Get.new(url)
       request["content-type"] = 'application/json'

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -15,6 +15,7 @@ development:
   mailgun_api_key: <%= ENV["MAILGUN_API_KEY"] %>
   sentry_dsn: <%= ENV["SENTRY_DSN"] %>
   email_recipients: <%= ENV["EMAIL_RECIPIENTS"] %>
+  maps_api_key: <%= ENV["MAPS_API_KEY"] %>
 
 test:
   secret_key_base: 20d3677777a4d91224471ae2f714e0a4391f868a81b8a85de07451354ef706096ba731556ae44593f30f81cb248269051f430fe86afd2d1e648b719dcd8cfd2e


### PR DESCRIPTION
## Description
When a user submits a new SurveyResponse, we calculate their distance in miles from the surveying school using the Google Maps API. Google changed their API rules a little, so this PR updates our calls to their new standard.

To test that this feature is running correctly, you need the API key (I sent via Slack) in your _.env_. Once the API key is placed, run `rake database:correct_distances`.