### PR TITLE
Remove CARTO endpoints and fix asset load order

### DIFF
--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -11,7 +11,7 @@ const modes = [ {value: "w",    text: "Walk"},
                 {value: "t",    text: "Transit (city bus, subway, etc.)"},
                 {value: "cp",   text: "Carpool (with children from other families)"}
               ].map(option=> {
-                return { value: option.value, text: window.__(option.text) };
+                return { value: option.value, text: option.text};
               });
 
 const grades = [  { value: 'pk',   text: 'Pre-K'},
@@ -33,7 +33,7 @@ const grades = [  { value: 'pk',   text: 'Pre-K'},
 const yesNo = [ { value: 'y', text: 'Yes' },
                 { value: 'n', text: 'No'  }
               ].map(option=> {
-                return { value: option.value, text: window.__(option.text) };
+                return { value: option.value, text: option.text };
               });
 
 const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
@@ -44,7 +44,7 @@ const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
                   required
                   name={name}
                   onChange={onChange}
-                  label={ window.__(question) }
+                  label={ question }
                   options={ yesNo } />
       </div>
     )
@@ -96,7 +96,7 @@ class ChildSurvey extends Component {
           </div>
           <Form.Dropdown placeholder='Select from an option below' fluid selection
                     required
-                    label={ window.__('What grade is your child in?') }
+                    label={ 'What grade is your child in?' }
                     options={ grades }
                     labeled={ true }
                     onChange={this.updateGrade}
@@ -108,7 +108,7 @@ class ChildSurvey extends Component {
                     required
                     onChange={this.updateTo}
                     options={ modes }
-                    label={ window.__('How does your child get TO school on most days?') }
+                    label={ 'How does your child get TO school on most days?' }
                     name={ `survey_response[to_school_${this.state.id}]` } />
 
           <input type="hidden" name={`survey_response[to_school_${this.state.id}]`} value={this.state.to} />
@@ -125,7 +125,7 @@ class ChildSurvey extends Component {
                     required
                     onChange={this.updateFrom}
                     options={ modes }
-                    label={ window.__('How does your child get home FROM school on most days?') }
+                    label={ 'How does your child get home FROM school on most days?'}
                     name={ `survey_response[from_school_${this.state.id}]` } />
 
           <input type="hidden" name={`survey_response[from_school_${this.state.id}]`} value={this.state.from} />

--- a/app/javascript/components/intersecting-streets/StreetDropdown.js
+++ b/app/javascript/components/intersecting-streets/StreetDropdown.js
@@ -4,8 +4,9 @@ import { Form } from 'semantic-ui-react';
 import $ from 'jquery';
 import L from 'leaflet';
 
-const endpoint = "//mapc-admin.carto.com/api/v2/sql?q=";
-const muni_id = window.muni_id || 1;
+const endpoint = "https://prql.mapc.org/?query=";
+const token = "&token=e2e3101e16208f04f7415e36052ce59b"
+const muni_id = 1;
 const school = window.school || { lat: 42, lng: -71 };
 
 let muniCache = [];
@@ -50,7 +51,7 @@ class StreetDropdown extends Component {
       return this.setState({ munis: muniCache})
     }
 
-    return $.getJSON(`${endpoint}SELECT DISTINCT(town) as text, town_id as value FROM %22mapc-admin%22.survey_intersection ORDER BY town`)
+    return $.getJSON(`${endpoint}SELECT DISTINCT(town) as text, town_id as value FROM mapc.trans_street_intersections ORDER BY town${token}`)
       .then(data => {
         muniCache = data.rows;
         this.setState({ munis: muniCache })
@@ -58,7 +59,7 @@ class StreetDropdown extends Component {
   }
 
   InitialStreets(muni) {
-    return $.getJSON(`${endpoint}SELECT DISTINCT(st_name_1) AS text%20, st_name_1 AS value FROM%20%22mapc-admin%22.survey_intersection%20WHERE town_id=${muni} ORDER BY st_name_1`)
+    return $.getJSON(`${endpoint}SELECT DISTINCT(st_name_1) AS text, st_name_1 AS value FROM mapc.trans_street_intersections WHERE town_id=${muni} ORDER BY st_name_1 ${token}`)
       .then((data) => {
         this.setState({ initialStreets: data.rows });
       });
@@ -66,7 +67,7 @@ class StreetDropdown extends Component {
 
   IntersectingStreets(street) {
     let encodedStreet = street;
-    return $.getJSON(`${endpoint}SELECT DISTINCT(st_name_2) AS text, st_name_2 AS value FROM%20%22mapc-admin%22.survey_intersection%20WHERE st_name_1='${encodedStreet}' AND town_id=${this.state.muni} ORDER BY st_name_2`)
+    return $.getJSON(`${endpoint}SELECT DISTINCT(st_name_2) AS text, st_name_2 AS value FROM mapc.trans_street_intersections WHERE st_name_1='${encodedStreet}' AND town_id=${this.state.muni} ORDER BY st_name_2 ${token}`)
       .then((data) => {
         const sortedRows = data.rows.sort((a,b) => (a.text > b.text) ? 1 : -1);
 
@@ -77,7 +78,7 @@ class StreetDropdown extends Component {
 
   IntersectingPoints = (street) => {
     let encodedStreet = street;
-    return $.getJSON(`${endpoint}SELECT DISTINCT(st_name_2) AS text, lat, long AS lng FROM%20%22mapc-admin%22.survey_intersection%20WHERE st_name_1='${encodedStreet}' AND town_id=${this.state.muni}`)
+    return $.getJSON(`${endpoint}SELECT DISTINCT(st_name_2) AS text, lat, long AS lng FROM mapc.trans_street_intersections WHERE st_name_1='${encodedStreet}' AND town_id=${this.state.muni} ${token}`)
       .then((data) => {
         const sortedRows = data.rows.sort((a,b) => (a.text > b.text) ? 1 : -1);
         let latlngs = sortedRows.map((row) => { return [row.lat,row.lng]; });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,7 +5,6 @@
   <title>MA Safe Routes to School Parent Survey</title>
   <%= stylesheet_link_tag    'application', media: 'all' %>
   <%= stylesheet_link_tag 'react_modules/schoolmap.min', media: 'all' %>
-    <%= javascript_include_tag 'application' %>
       <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
       <%= csrf_meta_tags %>
 

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -30,9 +30,10 @@
         window.school = { lat: <%= @survey.school.wgs84_lat %>, lng: <%= @survey.school.wgs84_lng %> }
       </script>
 
-      <%= javascript_include_tag 'application' %>
+      
         <%= javascript_pack_tag 'components' %>
         <%= stylesheet_pack_tag 'components' %>
+        <%= javascript_include_tag 'application' %>
 
       <%= f.hidden_field :survey_id, value: @survey.id %>
       <%= f.submit 'Submit Survey' %>


### PR DESCRIPTION
## Description
* Fix load order of Javascript assets to allow survey submission
* Replace CARTO endpoints with PrQL endpoints to revive the intersecting-streets react component

My main concern here is that I had to remove the general all-call of `<%= javascript_include_tag 'application' %>` (the entry point to the compiled Javascript assets from `app/assets/javascripts`). Survey submission works with both clicking the map to enter geometry and using the intersecting streets component, and it works with multiple children entered as well. However, just because I haven't found the breaking point doesn't necessarily mean it isn't there.