### PR TITLE
Att/batch entry validation

### DIFF
--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -18,6 +18,7 @@ class SurveyResponsesController < ApplicationController
   def new
     if params[:school_id]
       @survey_response = SurveyResponse.new(school: School.find(params[:school_id]))
+      @school = School.find(params[:school_id])
     else
       @survey_response = SurveyResponse.new
     end

--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -19,6 +19,8 @@ class SurveyResponsesController < ApplicationController
     if params[:school_id]
       @survey_response = SurveyResponse.new(school: School.find(params[:school_id]))
       @school = School.find(params[:school_id])
+      @all_surveys = Survey.select(:id).where(:school_id => @school.id).all
+      # binding.pry
     else
       @survey_response = SurveyResponse.new
     end

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -14,15 +14,17 @@ function App() {
     const mapContainer = form.querySelector('.map-container');
     const geometry = form.querySelector('input[name="survey_response[geometry]"]');
     const formFields = Array.from(form.querySelectorAll('*[required]')); // the user might add more fields dynamically
+    const surveySelectDropdown = form.querySelector('.survey-id-selection')
     let noErrors = true;
     const ERROR_CLASS = 'error';
     const DEFAULT_POINT = 'POINT (-71 42)';
 
-    document.getElementsByClassName('leaflet-container')[0].addEventListener('click', function() {
-      if (geometry.value !== DEFAULT_POINT) {
-        mapContainer.classList.remove(ERROR_CLASS);
-      }
-    })
+    if (!surveySelectDropdown.querySelector('input[name="survey_response[survey_id]"]').getAttribute('value')) {
+      surveySelectDropdown.classList.add(ERROR_CLASS);
+      noErrors = false;
+    } else {
+      surveySelectDropdown.classList.remove(ERROR_CLASS)
+    }
 
     if (geometry.value === DEFAULT_POINT) {
       mapContainer.classList.add(ERROR_CLASS);
@@ -42,22 +44,18 @@ function App() {
       }
     });
 
-    // if (!window.surveyId) {
-    //   field.classList.add(ERROR_CLASS);
-    //   noErrors = false;
-    // }
-
     if (noErrors) {
       handleSubmit(event)
     }
   }
 
   const handleSubmit = (event) => {
-    const submit = document.querySelector("button[type='submit'")
+    const surveyId = +document.querySelector('[name="survey_response[survey_id]"]').getAttribute("value");
+    const submit = document.querySelector("button[type='submit']")
     submit.innerText="Submitting..."
     submit.disabled = true
     const submission = new FormData(event.target)
-    submission.append("survey_response[survey_id]", window.survey_id)
+    submission.append("survey_response[survey_id]", surveyId)
     axios({
       method: 'post',
       url: '/survey_responses',
@@ -68,6 +66,7 @@ function App() {
     .then(function (response) {
       submit.innerText="Submitted"
       document.querySelector('.submit__results-text').innerText = response.data.message
+      sessionStorage.setItem("surveyId", window.survey_id)
     })
     .catch(function (error) {
       console.log(error);

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -19,11 +19,13 @@ function App() {
     const ERROR_CLASS = 'error';
     const DEFAULT_POINT = 'POINT (-71 42)';
 
-    if (!surveySelectDropdown.querySelector('input[name="survey_response[survey_id]"]').getAttribute('value')) {
-      surveySelectDropdown.classList.add(ERROR_CLASS);
-      noErrors = false;
-    } else {
-      surveySelectDropdown.classList.remove(ERROR_CLASS)
+    if (surveySelectDropdown) {
+      if (!surveySelectDropdown.querySelector('input[name="survey_response[survey_id]"]').getAttribute('value')) {
+        surveySelectDropdown.classList.add(ERROR_CLASS);
+        noErrors = false;
+      } else {
+        surveySelectDropdown.classList.remove(ERROR_CLASS)
+      }
     }
 
     if (geometry.value === DEFAULT_POINT) {
@@ -50,7 +52,7 @@ function App() {
   }
 
   const handleSubmit = (event) => {
-    const surveyId = +document.querySelector('[name="survey_response[survey_id]"]').getAttribute("value");
+    const surveyId = window.isBulkEntry ? +document.querySelector('[name="survey_response[survey_id]"]').getAttribute("value") : window.survey_id;
     const submit = document.querySelector("button[type='submit']")
     submit.innerText="Submitting..."
     submit.disabled = true
@@ -65,11 +67,13 @@ function App() {
     })
     .then(function (response) {
       submit.innerText="Submitted"
-      document.querySelector('.submit__results-text').innerText = response.data.message
-      sessionStorage.setItem("surveyId", window.survey_id)
+      document.querySelector('.submit__results-text').innerText = "Survey response was successfully created. Page refreshing momentarily..."
+      setTimeout(function() { location.reload(); }, 2000);
     })
     .catch(function (error) {
       console.log(error);
+      submit.innerText="Submission failed"
+      document.querySelector('.submit__results-text').innerText = "Something went wrong. Please contact an administrator."
     })
   }
 

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -42,6 +42,11 @@ function App() {
       }
     });
 
+    // if (!window.surveyId) {
+    //   field.classList.add(ERROR_CLASS);
+    //   noErrors = false;
+    // }
+
     if (noErrors) {
       handleSubmit(event)
     }

--- a/app/views/survey_responses/new.html.erb
+++ b/app/views/survey_responses/new.html.erb
@@ -8,6 +8,7 @@
     <% if @survey_response.school.surveys.count > 0 %>
       <script type="text/javascript">
         window.school = { lat: <%= @school.wgs84_lat %>, lng: <%= @school.wgs84_lng %> }
+        window.isBulkEntry = true;
       </script>
       <%= form_for @survey_response do |f| %>
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css">

--- a/app/views/survey_responses/new.html.erb
+++ b/app/views/survey_responses/new.html.erb
@@ -9,12 +9,9 @@
     <% if @survey_response.school.surveys.count > 0 %>
       <%= form_for @survey_response do |f| %>
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css">
-        <div class="field" id="root"><div id="map-container"></div></div>
-        <script type="text/javascript">
-          window.muni_id = <%= @survey_response.school.muni_id %>;
-          window.school = { lat: <%= @survey_response.school.wgs84_lat %>, lng: <%= @survey_response.school.wgs84_lng %> };
-        </script>
-        <%= javascript_include_tag "react_modules/intersectingstreets.min.js" %>
+        <div class="field surveyFormBox" id="root">
+          <div id="map-container"></div>
+        </div>
         <div><p>Select Survey by Begin Date</p></div>
         <div class="ui selection dropdown noreact">
           <input type="hidden" name="survey_response[survey_id]">
@@ -24,6 +21,14 @@
             <%- @survey_response.school.surveys.each do |survey| %>
               <div class="item" data-value="<%= survey.id %>"><%= survey.begin %></div>
             <% end %>
+            <script type="text/javascript">
+              window.school = { lat: <%= @school.wgs84_lat %>, lng: <%= @school.wgs84_lng %> }
+              window.survey_id = document.querySelector('[name="survey_response[survey_id]"]').getAttribute("value")
+              console.log(window.survey_id)
+            </script>
+            <%= javascript_pack_tag 'components' %>
+            <%= stylesheet_pack_tag 'components' %>
+            <%= javascript_include_tag 'application' %>
           </div>
         </div>
         <div class="button">

--- a/app/views/survey_responses/new.html.erb
+++ b/app/views/survey_responses/new.html.erb
@@ -5,15 +5,14 @@
 <div class="ui container">
   <div class="ui segment">
     <h1>New Survey Response</h1>
-
     <% if @survey_response.school.surveys.count > 0 %>
+      <script type="text/javascript">
+        window.school = { lat: <%= @school.wgs84_lat %>, lng: <%= @school.wgs84_lng %> }
+      </script>
       <%= form_for @survey_response do |f| %>
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css">
-        <div class="field surveyFormBox" id="root">
-          <div id="map-container"></div>
-        </div>
-        <div><p>Select Survey by Begin Date</p></div>
-        <div class="ui selection dropdown noreact">
+        <p>Select Survey by Begin Date</p>
+        <div class="ui selection dropdown noreact survey-id-selection">
           <input type="hidden" name="survey_response[survey_id]">
           <i class="dropdown icon"></i>
           <div class="default text">Select Survey by Begin Date</div>
@@ -21,19 +20,14 @@
             <%- @survey_response.school.surveys.each do |survey| %>
               <div class="item" data-value="<%= survey.id %>"><%= survey.begin %></div>
             <% end %>
-            <script type="text/javascript">
-              window.school = { lat: <%= @school.wgs84_lat %>, lng: <%= @school.wgs84_lng %> }
-              window.survey_id = document.querySelector('[name="survey_response[survey_id]"]').getAttribute("value")
-              console.log(window.survey_id)
-            </script>
-            <%= javascript_pack_tag 'components' %>
-            <%= stylesheet_pack_tag 'components' %>
-            <%= javascript_include_tag 'application' %>
           </div>
         </div>
-        <div class="button">
-          <%= f.submit 'Submit Survey' %>
+        <div class="field surveyFormBox" id="root">
+          <div id="map-container"></div>
         </div>
+        <%= javascript_pack_tag 'components' %>
+        <%= stylesheet_pack_tag 'components' %>
+        <%= javascript_include_tag 'application' %>
       <% end %>
     <% else %>
       This school has no surveys. <%= link_to 'Create one here.', school_path(@survey_response.school) %>

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -27,6 +27,7 @@
     <script type="text/javascript">
       window.survey_id = <%= @survey.id %>
       window.school = { lat: <%= @survey.school.wgs84_lat %>, lng: <%= @survey.school.wgs84_lng %> }
+      window.isBulkEntry = false
     </script>
     <%= javascript_pack_tag 'components' %>
     <%= stylesheet_pack_tag 'components' %>


### PR DESCRIPTION
## Description
This branch fixes the Intersecting-Streets component on the bulk entry survey submission page (found by going to Districts > select district with active survey > Batch Entry for school with active survey). It also adds form validation for the survey selection field, if it exists on the page. Additionally, non-200 POST responses are met with an error message that the user can see without pulling up the console and successful POSTs are greeted with a success message before the page refreshes.

Two things worth noting:
* Currently, the dropdown does not remember the last survey selected in bulk entry. While it was fairly straightforward to put the survey ID in session storage, grabbing that value in the Rails template proves to be more of a challenge. Additionally, our styled dropdowns (divs and input tags) are a bit tricky to handle in markup.
* The `distance` field is not calculated for survey responses, even after running `rake database:correct_distances`. This is the case for running master on dev, though, and since distances *are* being calculated on production, I think this has more to do with my database configuration (I recently had to remove and re-install my copy of this repo) than it does with the actual code. However, it's definitely something to keep an eye on once it goes to staging.