### PR TITLE
Save last-submitted survey ID in session storage

### DIFF
--- a/app/assets/javascripts/survey_responses.js
+++ b/app/assets/javascripts/survey_responses.js
@@ -5,4 +5,7 @@ $(document)
     $('.ui.selection.dropdown.noreact')
       .dropdown()
     ;
+    if (sessionStorage.getItem('lastSubmittedSurveyId')) {
+      $('.selected-survey').val(sessionStorage.getItem('lastSubmittedSurveyId'))
+    }
   });

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -68,7 +68,8 @@ function App() {
     .then(function (response) {
       submit.innerText="Submitted"
       document.querySelector('.submit__results-text').innerText = "Survey response was successfully created. Page refreshing momentarily..."
-      setTimeout(function() { location.reload(); }, 2000);
+      sessionStorage.setItem('lastSubmittedSurveyId', surveyId);
+      setTimeout(function() { location.reload(); }, 1000);
     })
     .catch(function (error) {
       console.log(error);

--- a/app/views/survey_responses/new.html.erb
+++ b/app/views/survey_responses/new.html.erb
@@ -14,7 +14,7 @@
         <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.3/leaflet.css">
         <p>Select Survey by Begin Date</p>
         <div class="ui selection dropdown noreact survey-id-selection">
-          <input type="hidden" name="survey_response[survey_id]">
+          <input type="hidden" name="survey_response[survey_id]" class="selected-survey">
           <i class="dropdown icon"></i>
           <div class="default text">Select Survey by Begin Date</div>
           <div class="menu">


### PR DESCRIPTION
Resolves #223 

## Description
Using sessionStorage and some handily-bundled jQuery, the last-submitted survey ID is saved upon page refresh. The user can still change the survey ID of the next submission, and then the new survey ID would be saved.

For convenience, I also decreased the refresh timeout from 2 seconds to 1. Given that the page does not refresh upon hitting an error, I figured that the user would value getting to the next screen more quickly than reading the success message every time. However, this can easily be undone if that assumption proves false.