### PR TITLE
Att/229 authorization

### DIFF
--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -1,5 +1,6 @@
 class SurveyResponsesController < ApplicationController
   before_action :set_survey_response, only: [:show, :edit, :update, :destroy]
+  before_action :authenticate_district_user, only: [:new]
 
   # GET /survey_responses
   # GET /survey_responses.json
@@ -72,6 +73,14 @@ class SurveyResponsesController < ApplicationController
 
   private
     # Use callbacks to share common setup or constraints between actions.
+    def authenticate_district_user
+      redirect_to '/', alert: 'Not authorized - please notify program coordinator to grant access.' unless access_whitelist
+    end
+
+    def access_whitelist
+      current_user.try(:is_admin?) || current_user.try(:is_district?)
+    end
+
     def set_survey_response
       @survey_response = SurveyResponse.find(params[:id])
     end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -8,6 +8,7 @@ class SurveysController < ApplicationController
   before_action :set_survey, only: [:show, :edit, :update, :destroy, :show_report]
   before_action :authenticate_user!, except: [:show]
   before_action :authenticate_district_user, except: [:show]
+  before_action :check_survey_date, only: [:show]
   # GET /surveys/1
   # GET /surveys/1.json
   def show
@@ -69,6 +70,15 @@ class SurveysController < ApplicationController
     def set_survey
       @survey = Survey.find(params[:id])
     end
+
+    def check_survey_date
+      @survey = Survey.find(params[:id])
+
+      if Date.today > @survey.end
+        redirect_to '/', alert: 'Survey closed - please notify program coordinator to submit response.'
+      end
+    end
+
 
     def authenticate_district_user
       redirect_to '/', alert: 'Not authorized - please notify program coordinator to grant access.' unless access_whitelist


### PR DESCRIPTION
## Description
A couple of private methods to be called before GET-ing the bulk entry (for non-admin/non-district permission users) and the public form (for checking if a survey is closed). As I mentioned on Slack, I'm pondering whether or not it makes sense to add further checks to the corresponding survey response POST request and/or to other POST/PUT/PATCH/DELETE requests, instead of just letting the UI direct users away from what they can or can't do.

Before diving too much more into that, though, I wanted to run these by you and make sure that they seemed in-line with how these checks are supposed to run in Rails.
