### PR TITLE
Remove extra copies of packages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,7 +13,7 @@
 //= require jquery
 //= require jquery_ujs
 //= require semantic-ui
-//= require bootstrap-datepicker
+//= require bootstrap-datepicker/core
 //= require_tree .
 //= require_tree ./locale
 //= require gettext/all

--- a/app/views/survey_responses/new.html.erb
+++ b/app/views/survey_responses/new.html.erb
@@ -28,7 +28,6 @@
         </div>
         <%= javascript_pack_tag 'components' %>
         <%= stylesheet_pack_tag 'components' %>
-        <%= javascript_include_tag 'application' %>
       <% end %>
     <% else %>
       This school has no surveys. <%= link_to 'Create one here.', school_path(@survey_response.school) %>

--- a/app/views/surveys/show.html.erb
+++ b/app/views/surveys/show.html.erb
@@ -31,6 +31,5 @@
     </script>
     <%= javascript_pack_tag 'components' %>
     <%= stylesheet_pack_tag 'components' %>
-    <%= javascript_include_tag 'application' %>
   </div>
 </div>


### PR DESCRIPTION
I was a bit on the fence about whether or not to set this as its own branch/PR or to try and include it elsewhere, but figured branches are free and it never hurts to get a full second opinion.

Long story short, there's a lot of assets in the live version, and it makes load time really slow (particularly on older devices or on mobile). This commit speeds things up with two main sources of "cleanup":

1. Remove the various non-English versions of the `bootstrap-datepicker-rails` gem. While MySchoolCommute does offer some degree of localization, this does not currently extend into the admin views (where this gem is used---particularly, in the creation of a new survey). The datepicker gem has [a LOT](https://github.com/Nerian/bootstrap-datepicker-rails/tree/master/vendor/assets/javascripts/bootstrap-datepicker/locales) of different locales included by default. If we eventually wanted to translate the admin panel into other languages, this would be useful, but for now simply adding `//= require bootstrap-datepicker/core` to our Javascript manifest speeds things up.
2. I removed `<%= javascript_include_tag 'application' %>` from both the bulk entry and public-facing form, as this was simply bringing in that same asset pipeline a second time on those two pages.

Overall, nothing changes functionality-wise; it just speeds everything up. I may have misunderstood an original intent in one (or both) of these changes, so please let me know if either of these present obvious problems!