### PR TITLE
Att/229 add pundit

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,6 +42,7 @@ gem 'bootstrap-datepicker-rails', '1.3.1.1'
 gem 'devise'
 gem 'devise_invitable'
 gem 'mailgun_rails'
+gem 'pundit'
 
 gem 'scenic'
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,8 @@ GEM
       binding_of_caller (>= 0.7)
       pry (>= 0.9.11)
     public_suffix (3.0.3)
+    pundit (2.1.0)
+      activesupport (>= 3.0.0)
     rack (2.2.3)
     rack-protection (2.0.5)
       rack
@@ -403,6 +405,7 @@ DEPENDENCIES
   pry-byebug
   pry-rescue
   pry-stack_explorer
+  pundit
   rails
   recaptcha
   rgeo

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,4 +5,12 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :set_gettext_locale
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
+
+
+  private
+  def user_not_authorized
+    flash[:alert] = "You are not authorized to perform this action."
+    redirect_to(request.referrer || root_path)
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
+  include Pundit
   protect_from_forgery with: :exception
 
   before_action :set_gettext_locale

--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -34,6 +34,7 @@ class SurveyResponsesController < ApplicationController
   # POST /survey_responses.json
   def create
     @survey_response = SurveyResponse.new(survey_response_params)
+    authorize @survey_response
     respond_to do |format|
       if @survey_response.save
         format.json { render json: {message: "Survey response was successfully created."} }

--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -1,6 +1,5 @@
 class SurveyResponsesController < ApplicationController
   before_action :set_survey_response, only: [:show, :edit, :update, :destroy]
-
   # GET /survey_responses
   # GET /survey_responses.json
   def index
@@ -16,6 +15,7 @@ class SurveyResponsesController < ApplicationController
 
   # GET /survey_responses/new
   def new
+    authorize SurveyResponse
     if params[:school_id]
       @survey_response = SurveyResponse.new(school: School.find(params[:school_id]))
       @school = School.find(params[:school_id])

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -11,6 +11,8 @@ class SurveysController < ApplicationController
   # GET /surveys/1
   # GET /surveys/1.json
   def show
+    @survey = Survey.find(params[:id])
+    authorize @survey
   end
 
   # GET /surveys/new

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -8,6 +8,7 @@ class SurveysController < ApplicationController
   before_action :set_survey, only: [:show, :edit, :update, :destroy, :show_report]
   before_action :authenticate_user!, except: [:show]
   before_action :authenticate_district_user, except: [:show]
+  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   # GET /surveys/1
   # GET /surveys/1.json
   def show
@@ -68,6 +69,11 @@ class SurveysController < ApplicationController
 
   private
     # Use callbacks to share common setup or constraints between actions.
+    def user_not_authorized
+      flash[:alert] = "You are not authorized to perform this action."
+      redirect_to(request.referrer || root_path)
+    end
+
     def set_survey
       @survey = Survey.find(params[:id])
     end

--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -8,7 +8,6 @@ class SurveysController < ApplicationController
   before_action :set_survey, only: [:show, :edit, :update, :destroy, :show_report]
   before_action :authenticate_user!, except: [:show]
   before_action :authenticate_district_user, except: [:show]
-  rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   # GET /surveys/1
   # GET /surveys/1.json
   def show
@@ -69,10 +68,6 @@ class SurveysController < ApplicationController
 
   private
     # Use callbacks to share common setup or constraints between actions.
-    def user_not_authorized
-      flash[:alert] = "You are not authorized to perform this action."
-      redirect_to(request.referrer || root_path)
-    end
 
     def set_survey
       @survey = Survey.find(params[:id])

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,0 +1,49 @@
+class ApplicationPolicy
+  attr_reader :user, :record
+
+  def initialize(user, record)
+    @user = user
+    @record = record
+  end
+
+  def index?
+    false
+  end
+
+  def show?
+    false
+  end
+
+  def create?
+    false
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    false
+  end
+
+  def edit?
+    update?
+  end
+
+  def destroy?
+    false
+  end
+
+  class Scope
+    attr_reader :user, :scope
+
+    def initialize(user, scope)
+      @user = user
+      @scope = scope
+    end
+
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/policies/survey_policy.rb
+++ b/app/policies/survey_policy.rb
@@ -1,5 +1,5 @@
 class SurveyPolicy < ApplicationPolicy
   def show?
-    record.begin?
+    record.end > Date.today
   end
 end

--- a/app/policies/survey_policy.rb
+++ b/app/policies/survey_policy.rb
@@ -1,0 +1,5 @@
+class SurveyPolicy < ApplicationPolicy
+  def show?
+    record.begin?
+  end
+end

--- a/app/policies/survey_response_policy.rb
+++ b/app/policies/survey_response_policy.rb
@@ -1,6 +1,10 @@
 class SurveyResponsePolicy < ApplicationPolicy
   def new?
-    puts 'Accessing new policy'
     user != nil and (user.is_admin? or user.is_district?)
+  end
+
+  def create?
+    survey = Survey.find(record.survey_id)
+    (user != nil and (user.is_admin? or user.is_district?)) or survey.end > Date.today
   end
 end

--- a/app/policies/survey_response_policy.rb
+++ b/app/policies/survey_response_policy.rb
@@ -1,0 +1,6 @@
+class SurveyResponsePolicy < ApplicationPolicy
+  def new?
+    puts 'Accessing new policy'
+    user != nil and (user.is_admin? or user.is_district?)
+  end
+end


### PR DESCRIPTION
## Description

Resolves #229 

Per your suggestion, I re-wrote the authorization checks from my draft [att/229-authorization](https://github.com/MAPC/myschoolcommute2/pull/240) branch with the [Pundit gem
](https://github.com/varvet/pundit). I think eventually abstracting some of this to handle all permissions for non-users, admin users, and district users will serve us well. For example, `authenticate_district_user` is a private method used in a few different controllers that checks user permissions via a whitelist method, and a similar check could be done with Pundit. For now, though, the immediate authorization concerns are covered.