### PR TITLE
Att/245 remove student

### DIFF
--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -96,7 +96,7 @@ function App() {
   return (
     <Form onSubmit={() => console.log("!")} className="new_survey_response" id="new_survey_response">
       {/* <form className="new_survey_response" id="new_survey_response" acceptCharset="UTF-8" _lpchecked="1" onSubmit={verifySubmission}> */}
-        <StreetDropdown />
+        {/* <StreetDropdown /> */}
         <ChildSurveys />
         <label>{ window.__('How many vehicles do you have in your household?') }</label>
         <Dropdown 

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -62,7 +62,6 @@ function App() {
       if (!surveySelectDropdown.querySelector('input[name="survey_response[survey_id]"]').getAttribute('value')) {
         surveySelectDropdown.classList.add(ERROR_CLASS);
         noErrors = false;
-        return;
       } else {
         surveySelectDropdown.classList.remove(ERROR_CLASS)
       }
@@ -72,7 +71,6 @@ function App() {
     if (state.chosenLatLng === DEFAULT_POINT) {
       mapContainer.classList.add(ERROR_CLASS);
       noErrors = false;
-      return;
     }
     else {
       mapContainer.classList.remove(ERROR_CLASS);
@@ -86,7 +84,6 @@ function App() {
       if (!state.studentInfo[studentId][`${studentField}`]) {
         field.classList.add(ERROR_CLASS);
         noErrors = false;
-        return;
       }
     });
 

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import StreetDropdown from './intersecting-streets/StreetDropdown';
 import ChildSurveys from './intersecting-streets/ChildSurveys';
-import { Button } from 'semantic-ui-react';
+import { Form, Button, Dropdown } from 'semantic-ui-react';
 import axios from 'axios';
 import './intersecting-streets/App.css';
 
@@ -79,15 +79,39 @@ function App() {
     })
   }
 
+  const counts = [  { value: '0', text: '0'  },
+                  { value: '1', text: '1'  },
+                  { value: '2', text: '2'  },
+                  { value: '3', text: '3'  },
+                  { value: '4', text: '4'  },
+                  { value: '5', text: '5'  },
+                  { value: '6', text: '6'  },
+                  { value: '7', text: '7'  },
+                  { value: '8', text: '8'  },
+                  { value: '9', text: '9'  } ];
+
   return (
-    <>
-      <form className="new_survey_response" id="new_survey_response" acceptCharset="UTF-8" _lpchecked="1" onSubmit={verifySubmission}>
+    <Form onSubmit={() => console.log("!")} className="new_survey_response" id="new_survey_response">
+      {/* <form className="new_survey_response" id="new_survey_response" acceptCharset="UTF-8" _lpchecked="1" onSubmit={verifySubmission}> */}
         <StreetDropdown />
         <ChildSurveys />
+        <label>{ window.__('How many vehicles do you have in your household?') }</label>
+        <Dropdown 
+          placeholder='Select from an option below' fluid selection
+          options={ counts }
+          onChange={(value) => updateNrVehicles(value)}
+          name={ 'survey_response[nr_vehicles]' }
+        />
+        <label>{ window.__("How many people in your household have a driver's license?") }</label>
+        <Dropdown
+          placeholder="Select from an option below" fluid selection
+          options={ counts }
+          onChange={(value) => updateNrLicenses(value)}
+          name={ 'survey_response[nr_licenses]' }
+        />
         <Button type='submit'>Submit</Button>
-      </form>
       <div className="submit__results-text"></div>
-    </>
+    </Form>
   )
 }
 

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,11 +1,51 @@
-import React, { useState } from 'react';
+import React, { useReducer } from 'react';
 import StreetDropdown from './intersecting-streets/StreetDropdown';
 import ChildSurveys from './intersecting-streets/ChildSurveys';
 import { Form, Button, Dropdown } from 'semantic-ui-react';
 import axios from 'axios';
 import './intersecting-streets/App.css';
 
+function reducer(state, action) {
+  switch(action.type) {
+    case 'updateStudent':
+      const updatedStudentInfo = state.studentInfo
+      updatedStudentInfo[`${action.id}`][`${action.property}`] = action.value;
+      return { ...state, studentInfo: updatedStudentInfo }
+    case 'addStudent':
+      const increasedStudentInfo = state.studentInfo
+      increasedStudentInfo.push({
+        grade: '',
+        to_school: '',
+        dropoff: '',
+        from_school: '',
+        pickup: ''
+      })
+      return { ...state, studentInfo: increasedStudentInfo }
+    case 'removeStudent':
+      const removedStudentInfo = state.studentInfo
+      removedStudentInfo.splice([`${action.id}`], 1)
+      return { ...state, studentInfo: removedStudentInfo}
+    case 'updateVehicles':
+      return {...state, nrVehicles: action.value}
+    case 'updateLicenses':
+      return {...state, nrLicenses: action.value}
+    default:
+      throw new Error();
+  }
+}
+
 function App() {
+  const [state, dispatch] = useReducer(reducer, {
+    studentInfo: [{
+      grade: '',
+      to_school: '',
+      dropoff: '',
+      from_school: '',
+      pickup: '',
+    }],
+    nrLicenses: '',
+    nrVehicles: '',
+  })
   const csrfToken = document.querySelector('[name=csrf-token]').content
 
   const verifySubmission = (event) => {
@@ -90,26 +130,26 @@ function App() {
                   { value: '8', text: '8'  },
                   { value: '9', text: '9'  } ];
   
-  const [nrVehicles, updateNrVehicles] = useState();
-  const [nrLicenses, updateNrLicenses] = useState();
-
   return (
     <Form onSubmit={() => console.log("!")} className="new_survey_response" id="new_survey_response">
       {/* <form className="new_survey_response" id="new_survey_response" acceptCharset="UTF-8" _lpchecked="1" onSubmit={verifySubmission}> */}
-        {/* <StreetDropdown /> */}
-        <ChildSurveys />
+        <StreetDropdown />
+        <ChildSurveys 
+          studentInfo={state.studentInfo}
+          dispatch={dispatch}
+        />
         <label>{ window.__('How many vehicles do you have in your household?') }</label>
         <Dropdown 
           placeholder='Select from an option below' fluid selection
           options={ counts }
-          onChange={(value) => updateNrVehicles(value)}
+          onChange={(e, {value}) => dispatch({type: 'updateVehicles', value: value})}
           name={ 'survey_response[nr_vehicles]' }
         />
         <label>{ window.__("How many people in your household have a driver's license?") }</label>
         <Dropdown
           placeholder="Select from an option below" fluid selection
           options={ counts }
-          onChange={(value) => updateNrLicenses(value)}
+          onChange={(e, {value}) => dispatch({type: 'updateLicenses', value: value})}
           name={ 'survey_response[nr_licenses]' }
         />
         <Button type='submit'>Submit</Button>

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import StreetDropdown from './intersecting-streets/StreetDropdown';
 import ChildSurveys from './intersecting-streets/ChildSurveys';
 import { Form, Button, Dropdown } from 'semantic-ui-react';
@@ -89,6 +89,9 @@ function App() {
                   { value: '7', text: '7'  },
                   { value: '8', text: '8'  },
                   { value: '9', text: '9'  } ];
+  
+  const [nrVehicles, updateNrVehicles] = useState();
+  const [nrLicenses, updateNrLicenses] = useState();
 
   return (
     <Form onSubmit={() => console.log("!")} className="new_survey_response" id="new_survey_response">

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -7,6 +7,8 @@ import './intersecting-streets/App.css';
 
 function reducer(state, action) {
   switch(action.type) {
+    case 'updateLatLng':
+      return {...state, chosenLatLng: action.value}
     case 'updateStudent':
       const updatedStudentInfo = state.studentInfo
       updatedStudentInfo[`${action.id}`][`${action.property}`] = action.value;
@@ -36,6 +38,7 @@ function reducer(state, action) {
 
 function App() {
   const [state, dispatch] = useReducer(reducer, {
+    chosenLatLng: '',
     studentInfo: [{
       grade: '',
       to_school: '',
@@ -133,7 +136,9 @@ function App() {
   return (
     <Form onSubmit={() => console.log("!")} className="new_survey_response" id="new_survey_response">
       {/* <form className="new_survey_response" id="new_survey_response" acceptCharset="UTF-8" _lpchecked="1" onSubmit={verifySubmission}> */}
-        <StreetDropdown />
+        <StreetDropdown 
+          dispatch={dispatch}
+        />
         <ChildSurveys 
           studentInfo={state.studentInfo}
           dispatch={dispatch}

--- a/app/javascript/components/intersecting-streets/App.css
+++ b/app/javascript/components/intersecting-streets/App.css
@@ -33,3 +33,9 @@ body {
 .map-container {
   width: 100%;
 }
+
+.ui.top.attached.label.child-survey__header {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+}

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -36,17 +36,18 @@ const yesNo = [ { value: 'y', text: 'Yes' },
                 return { value: option.value, text: window.__(option.text) };
               });
 
-const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
+const TripReasonQuestion = ({id, idText, mode, question, onChange, studentInfo}) => {
   if (mode === 'fv' || mode === 'cp' ) {
     return (
-      <div className="field">
-        <Form.Dropdown placeholder={question} fluid selection
-                  required
-                  name={name}
-                  onChange={onChange}
-                  label={ window.__(question) }
-                  options={ yesNo } />
-      </div>
+      <Form.Dropdown 
+        placeholder={question} fluid selection
+        id={`${idText}_${id}`}
+        required
+        onChange={onChange}
+        label={ window.__(question) }
+        options={ yesNo }
+        value={studentInfo[`${id}`][`${idText}`]}
+      />
     )
   } else {
     return null
@@ -76,7 +77,7 @@ const ChildSurvey = ({id, studentInfo, dispatch}) => {
           label={ window.__('What grade is your child in?') }
           options={ grades }
           onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'grade'})}
-          name={ `survey_response[grade_${id}]` }
+          id={`grade_${id}`}
           value={studentInfo[`${id}`].grade}
         />
         <Form.Dropdown
@@ -85,16 +86,17 @@ const ChildSurvey = ({id, studentInfo, dispatch}) => {
           onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'to_school'})}
           options={ modes }
           label={ window.__('How does your child get TO school on most days?') }
-          name={ `survey_response[to_school_${id}]` }
+          id={`to_school_${id}`}
           value={studentInfo[`${id}`].to_school}
         />
         <TripReasonQuestion
           id={id}
+          idText={`dropoff`}
           mode={studentInfo[`${id}`].to_school}
           onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'dropoff'})}
-          name={ `survey_response[dropoff_${id}]` }
           question='Do you usually drop off your child on your way to work or another destination (other than home)?'
           value={studentInfo[`${id}`].dropoff}
+          studentInfo={studentInfo}
         />
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
@@ -102,16 +104,17 @@ const ChildSurvey = ({id, studentInfo, dispatch}) => {
           onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'from_school'})}
           options={ modes }
           label={ window.__('How does your child get home FROM school on most days?') }
-          name={ `survey_response[from_school_${id}]` }
+          id={`from_school_${id}`}
           value={studentInfo[`${id}`].from_school}
         />
         <TripReasonQuestion
           id={id}
+          idText={`pickup`}
           mode={studentInfo[`${id}`].from_school}
           onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'pickup'})}
-          name={ `survey_response[pickup_${id}]` }
           question='Do you usually pick up your child on your way from work or another location (other than home)?'
           value={studentInfo[`${id}`].pickup}
+          studentInfo={studentInfo}
         />
       </div>
     </div>

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -53,33 +53,10 @@ const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
   }
 }
 
-const deleteStudentEntry = (e, id, studentInfo, setStudentInfo, count, setStudentCount) => {
-  e.preventDefault()
-  setStudentInfo(() => {
-    console.log(`Delete id ${id} out of ${count} total objects`)
-    let tempStudentInfo = studentInfo;
-     for (let i = id; i <= count; i++) {
-      tempStudentInfo[`grade_${i}`] = tempStudentInfo[`grade_${i+1}`]
-      tempStudentInfo[`to_school_${i-1}`] = tempStudentInfo[`to_school_${i}`]
-      tempStudentInfo[`dropoff_${i-1}`] = tempStudentInfo[`dropoff_${i}`]
-      tempStudentInfo[`from_school_${i-1}`] = tempStudentInfo[`from_school_${i}`]
-      tempStudentInfo[`pickup_${i-1}`] = tempStudentInfo[`pickup_${i}`]
-    }
-    delete tempStudentInfo[`grade_${count}`]
-    delete tempStudentInfo[`to_school_${count}`]
-    delete tempStudentInfo[`dropoff_${count}`]
-    delete tempStudentInfo[`from_school_${count}`]
-    delete tempStudentInfo[`pickup_${count}`]
-    return tempStudentInfo
-  })
-  
-  setStudentCount(count-1);
-}
-
-const ChildSurvey = ({id, setStudentCount, count, studentInfo, setStudentInfo}) => {
-  const deleteButton = id > 1
+const ChildSurvey = ({id, studentInfo, dispatch}) => {
+  const deleteButton = id > 0
     ? <button
-        onClick={(e) => deleteStudentEntry(e, id, studentInfo, setStudentInfo, count, setStudentCount)}
+        onClick={() => dispatch({type: 'removeStudent', id: id})}
         id={`remove${id}`}
       >
         x
@@ -90,7 +67,7 @@ const ChildSurvey = ({id, setStudentCount, count, studentInfo, setStudentInfo}) 
     <div className="child-survey">
       <div className="ui attached segment">
         <div className="ui top attached label child-survey__header">
-          <span>Child {id}</span>
+          <span>Child {id+1}</span>
           {deleteButton}
         </div>
         <Form.Dropdown
@@ -98,39 +75,43 @@ const ChildSurvey = ({id, setStudentCount, count, studentInfo, setStudentInfo}) 
           required
           label={ window.__('What grade is your child in?') }
           options={ grades }
-          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`grade_${id}`]: value}) }
+          onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'grade'})}
           name={ `survey_response[grade_${id}]` }
-          value={studentInfo[`grade_${id}`]}
+          value={studentInfo[`${id}`].grade}
         />
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
           required
-          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`to_school_${id}`]: value}) }
+          onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'to_school'})}
           options={ modes }
           label={ window.__('How does your child get TO school on most days?') }
           name={ `survey_response[to_school_${id}]` }
+          value={studentInfo[`${id}`].to_school}
         />
         <TripReasonQuestion
           id={id}
-          mode={studentInfo[`to_school_${id}`]}
-          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`dropoff_${id}`]: value}) }
+          mode={studentInfo[`${id}`].to_school}
+          onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'dropoff'})}
           name={ `survey_response[dropoff_${id}]` }
           question='Do you usually drop off your child on your way to work or another destination (other than home)?'
+          value={studentInfo[`${id}`].dropoff}
         />
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
           required
-          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`from_school_${id}`]: value}) }
+          onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'from_school'})}
           options={ modes }
           label={ window.__('How does your child get home FROM school on most days?') }
           name={ `survey_response[from_school_${id}]` }
+          value={studentInfo[`${id}`].from_school}
         />
         <TripReasonQuestion
           id={id}
-          mode={studentInfo[`from_school_${id}`]}
-          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`pickup_${id}`]: value}) }
+          mode={studentInfo[`${id}`].from_school}
+          onChange={(e, {value}) => dispatch({type: 'updateStudent', id: id, value: value, property: 'pickup'})}
           name={ `survey_response[pickup_${id}]` }
           question='Do you usually pick up your child on your way from work or another location (other than home)?'
+          value={studentInfo[`${id}`].pickup}
         />
       </div>
     </div>

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { useState, Component } from 'react';
 import { Form } from 'semantic-ui-react';
 
 // answers and values
@@ -53,94 +53,58 @@ const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
   }
 }
 
-class ChildSurvey extends Component {
-  constructor(props) {
-    super(props);
+const ChildSurvey = ({id, setStudentCount}) => {
+  const [toMethod, updateTo] = useState();
+  const [fromMethod, updateFrom] = useState();
+  const [grade, updateGrade] = useState();
+  const [dropoff, updateDropoff] = useState();
+  const [pickup, updatePickup] = useState();
 
-    this.state = {
-      to: '',
-      from: '',
-      id: props.id,
-      grade: '',
-      dropoff: '',
-      pickup: '',
-    }
-  }
-
-  updateTo = (event, el) => {
-    this.setState({ to: el.value });
-  }
-
-  updateFrom = (event, el) => {
-    this.setState({ from: el.value });
-  }
-
-  updateGrade = (event, { value }) => {
-    this.setState({ grade: value });
-  }
-
-  updateDropoff = (event, { value }) => {
-    this.setState({ dropoff: value });
-  }
-
-  updatePickup = (event, { value }) => {
-    this.setState({ pickup: value });
-  }
-
-  render() {
-    return (
-      <div className="child-survey">
-        <div className="ui attached segment">
-          <div className="ui top attached label">
-            Child { this.state.id }
-          </div>
-          <Form.Dropdown placeholder='Select from an option below' fluid selection
-                    required
-                    label={ window.__('What grade is your child in?') }
-                    options={ grades }
-                    labeled={ true }
-                    onChange={this.updateGrade}
-                    name={ `survey_response[grade_${this.state.id}]` } />
-
-          <input type="hidden" name={`survey_response[grade_${this.state.id}]`} value={this.state.grade} />
-
-          <Form.Dropdown placeholder='Select from an option below' fluid selection
-                    required
-                    onChange={this.updateTo}
-                    options={ modes }
-                    label={ window.__('How does your child get TO school on most days?') }
-                    name={ `survey_response[to_school_${this.state.id}]` } />
-
-          <input type="hidden" name={`survey_response[to_school_${this.state.id}]`} value={this.state.to} />
-
-          <TripReasonQuestion id={this.state.id}
-                            mode={this.state.to}
-                            onChange={this.updateDropoff}
-                            name={ `survey_response[dropoff_${this.state.id}]` }
-                            question='Do you usually drop off your child on your way to work or another destination (other than home)?' />
-
-          <input type="hidden" name={`survey_response[dropoff_${this.state.id}]`} value={this.state.dropoff} />
-
-          <Form.Dropdown placeholder='Select from an option below' fluid selection
-                    required
-                    onChange={this.updateFrom}
-                    options={ modes }
-                    label={ window.__('How does your child get home FROM school on most days?') }
-                    name={ `survey_response[from_school_${this.state.id}]` } />
-
-          <input type="hidden" name={`survey_response[from_school_${this.state.id}]`} value={this.state.from} />
-
-          <TripReasonQuestion id={this.state.id}
-                            mode={this.state.from}
-                            onChange={this.updatePickup}
-                            name={ `survey_response[pickup_${this.state.id}]` }
-                            question='Do you usually pick up your child on your way from work or another location (other than home)?' />
-
-          <input type="hidden" name={`survey_response[pickup_${this.state.id}]`} value={this.state.pickup} />
-        </div>
+  return (
+    <div className="child-survey">
+      <div className="ui attached segment">
+        <div className="ui top attached label">Child {id}</div>
+        <Form.Dropdown
+          placeholder='Select from an option below' fluid selection
+          required
+          label={ window.__('What grade is your child in?') }
+          options={ grades }
+          onChange={ (e, { value }) => updateGrade(value) }
+          name={ `survey_response[grade_${id}]` }
+        />
+        <Form.Dropdown
+          placeholder='Select from an option below' fluid selection
+          required
+          onChange={ (e, { value }) => updateTo(value)}
+          options={ modes }
+          label={ window.__('How does your child get TO school on most days?') }
+          name={ `survey_response[to_school_${id}]` }
+        />
+        <TripReasonQuestion
+          id={id}
+          mode={toMethod}
+          onChange={ (e, { value }) => updateDropoff(value)}
+          name={ `survey_response[dropoff_${id}]` }
+          question='Do you usually drop off your child on your way to work or another destination (other than home)?'
+        />
+        <Form.Dropdown
+          placeholder='Select from an option below' fluid selection
+          required
+          onChange={ (e, { value }) => updateFrom(value)}
+          options={ modes }
+          label={ window.__('How does your child get home FROM school on most days?') }
+          name={ `survey_response[from_school_${id}]` }
+        />
+        <TripReasonQuestion
+          id={id}
+          mode={fromMethod}
+          onChange={ (e, { value }) => updatePickup(value)}
+          name={ `survey_response[pickup_${id}]` }
+          question='Do you usually pick up your child on your way from work or another location (other than home)?'
+        />
       </div>
-    )
-  }
-}
+    </div>
+  )
+};
 
 export default ChildSurvey;

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -57,7 +57,10 @@ const TripReasonQuestion = ({id, idText, mode, question, onChange, studentInfo})
 const ChildSurvey = ({id, studentInfo, dispatch}) => {
   const deleteButton = id > 0
     ? <button
-        onClick={() => dispatch({type: 'removeStudent', id: id})}
+        onClick={(e) => {
+          e.preventDefault()
+          dispatch({type: 'removeStudent', id: id})}
+        }
         id={`remove${id}`}
       >
         x

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -53,22 +53,18 @@ const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
   }
 }
 
-const ChildSurvey = ({id, setStudentCount, count}) => {
-  const [toMethod, updateTo] = useState();
-  const [fromMethod, updateFrom] = useState();
-  const [grade, updateGrade] = useState();
-  const [dropoff, updateDropoff] = useState();
-  const [pickup, updatePickup] = useState();
-
-  const deleteButton = <button 
-    onClick={(e) => {
-      e.preventDefault()
-      console.log("?")  
-    }}
-    id={`remove${id}`}
-  >
-    x
-  </button>
+const ChildSurvey = ({id, setStudentCount, count, studentInfo, setStudentInfo}) => {
+  const deleteButton = id > 1
+    ? <button 
+        onClick={(e) => {
+          e.preventDefault()
+          setStudentCount(count-1)
+        }}
+        id={`remove${id}`}
+      >
+        x
+      </button>
+      : '';
   
 
   return (
@@ -76,52 +72,43 @@ const ChildSurvey = ({id, setStudentCount, count}) => {
       <div className="ui attached segment">
         <div className="ui top attached label child-survey__header">
           <span>Child {id}</span>
-          <button 
-            onClick={(e) => {
-              e.preventDefault()
-              setStudentCount(count-1)
-              console.log("?")  
-            }}
-            id={`remove${id}`}
-          >
-            x
-          </button>
+          {deleteButton}
         </div>
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
           required
           label={ window.__('What grade is your child in?') }
           options={ grades }
-          onChange={ (e, { value }) => updateGrade(value) }
+          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`grade_${id}`]: value}) }
           name={ `survey_response[grade_${id}]` }
         />
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
           required
-          onChange={ (e, { value }) => updateTo(value)}
+          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`to_school_${id}`]: value}) }
           options={ modes }
           label={ window.__('How does your child get TO school on most days?') }
           name={ `survey_response[to_school_${id}]` }
         />
         <TripReasonQuestion
           id={id}
-          mode={toMethod}
-          onChange={ (e, { value }) => updateDropoff(value)}
+          mode={studentInfo[`to_school_${id}`]}
+          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`dropoff_${id}`]: value}) }
           name={ `survey_response[dropoff_${id}]` }
           question='Do you usually drop off your child on your way to work or another destination (other than home)?'
         />
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
           required
-          onChange={ (e, { value }) => updateFrom(value)}
+          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`from_school_${id}`]: value}) }
           options={ modes }
           label={ window.__('How does your child get home FROM school on most days?') }
           name={ `survey_response[from_school_${id}]` }
         />
         <TripReasonQuestion
           id={id}
-          mode={fromMethod}
-          onChange={ (e, { value }) => updatePickup(value)}
+          mode={studentInfo[`from_school_${id}`]}
+          onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`pickup_${id}`]: value}) }
           name={ `survey_response[pickup_${id}]` }
           question='Do you usually pick up your child on your way from work or another location (other than home)?'
         />

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -53,17 +53,40 @@ const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
   }
 }
 
-const ChildSurvey = ({id, setStudentCount}) => {
+const ChildSurvey = ({id, setStudentCount, count}) => {
   const [toMethod, updateTo] = useState();
   const [fromMethod, updateFrom] = useState();
   const [grade, updateGrade] = useState();
   const [dropoff, updateDropoff] = useState();
   const [pickup, updatePickup] = useState();
 
+  const deleteButton = <button 
+    onClick={(e) => {
+      e.preventDefault()
+      console.log("?")  
+    }}
+    id={`remove${id}`}
+  >
+    x
+  </button>
+  
+
   return (
     <div className="child-survey">
       <div className="ui attached segment">
-        <div className="ui top attached label">Child {id}</div>
+        <div className="ui top attached label child-survey__header">
+          <span>Child {id}</span>
+          <button 
+            onClick={(e) => {
+              e.preventDefault()
+              setStudentCount(count-1)
+              console.log("?")  
+            }}
+            id={`remove${id}`}
+          >
+            x
+          </button>
+        </div>
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection
           required

--- a/app/javascript/components/intersecting-streets/ChildSurvey.js
+++ b/app/javascript/components/intersecting-streets/ChildSurvey.js
@@ -53,19 +53,38 @@ const TripReasonQuestion = ({id, mode, question, name, onChange}) => {
   }
 }
 
+const deleteStudentEntry = (e, id, studentInfo, setStudentInfo, count, setStudentCount) => {
+  e.preventDefault()
+  setStudentInfo(() => {
+    console.log(`Delete id ${id} out of ${count} total objects`)
+    let tempStudentInfo = studentInfo;
+     for (let i = id; i <= count; i++) {
+      tempStudentInfo[`grade_${i}`] = tempStudentInfo[`grade_${i+1}`]
+      tempStudentInfo[`to_school_${i-1}`] = tempStudentInfo[`to_school_${i}`]
+      tempStudentInfo[`dropoff_${i-1}`] = tempStudentInfo[`dropoff_${i}`]
+      tempStudentInfo[`from_school_${i-1}`] = tempStudentInfo[`from_school_${i}`]
+      tempStudentInfo[`pickup_${i-1}`] = tempStudentInfo[`pickup_${i}`]
+    }
+    delete tempStudentInfo[`grade_${count}`]
+    delete tempStudentInfo[`to_school_${count}`]
+    delete tempStudentInfo[`dropoff_${count}`]
+    delete tempStudentInfo[`from_school_${count}`]
+    delete tempStudentInfo[`pickup_${count}`]
+    return tempStudentInfo
+  })
+  
+  setStudentCount(count-1);
+}
+
 const ChildSurvey = ({id, setStudentCount, count, studentInfo, setStudentInfo}) => {
   const deleteButton = id > 1
-    ? <button 
-        onClick={(e) => {
-          e.preventDefault()
-          setStudentCount(count-1)
-        }}
+    ? <button
+        onClick={(e) => deleteStudentEntry(e, id, studentInfo, setStudentInfo, count, setStudentCount)}
         id={`remove${id}`}
       >
         x
       </button>
-      : '';
-  
+    : '';
 
   return (
     <div className="child-survey">
@@ -81,6 +100,7 @@ const ChildSurvey = ({id, setStudentCount, count, studentInfo, setStudentInfo}) 
           options={ grades }
           onChange={ (e, { value }) => setStudentInfo({...studentInfo, [`grade_${id}`]: value}) }
           name={ `survey_response[grade_${id}]` }
+          value={studentInfo[`grade_${id}`]}
         />
         <Form.Dropdown
           placeholder='Select from an option below' fluid selection

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -1,78 +1,31 @@
-import React, { Component } from 'react';
+import React, { useState } from 'react';
 import ChildSurvey from './ChildSurvey';
-import { Form, Button } from 'semantic-ui-react';
+import { Button } from 'semantic-ui-react';
 
-const counts = [  { value: '0', text: '0'  },
-                  { value: '1', text: '1'  },
-                  { value: '2', text: '2'  },
-                  { value: '3', text: '3'  },
-                  { value: '4', text: '4'  },
-                  { value: '5', text: '5'  },
-                  { value: '6', text: '6'  },
-                  { value: '7', text: '7'  },
-                  { value: '8', text: '8'  },
-                  { value: '9', text: '9'  } ];
+const ChildSurveys = () => {
+  const [count, addChild] = useState(1);
 
-class ChildSurveys extends Component {
-  constructor(props) {
-    super(props);
-
-    this.state = {
-      count: 1,
-      nrVehicles: '',
-      nrLicenses: '',
-    };
-  }
-
-  AddChild = () => {
-    this.setState({ count: this.state.count+1 })
-  }
-
-  updateNrVehicles = (event, { value }) => {
-    this.setState({ nrVehicles: value });
-  }
-
-  updateNrLicenses = (event, { value }) => {
-    this.setState({ nrLicenses: value });
-  }
-
-  render() {
-    let childSurveys = [];
-    for (var i = 0; i < this.state.count; i++) {
-      childSurveys.push(
-        <div key={i}>
-          <ChildSurvey id={i+1} />
-        </div>
-      );
-    }
-    return (
-      <div>
-        {childSurveys}
-        <Button onClick={this.AddChild}
-                type='button'
-                className="primary">
-          { window.__('Add another child at this school') }
-        </Button>
-
-        <Form.Dropdown placeholder='Select from an option below' fluid selection
-                  options={ counts }
-                  onChange={this.updateNrVehicles}
-                  label={ window.__('How many vehicles do you have in your household?') }
-                  name={ 'survey_response[nr_vehicles]' }/>
-
-        <input type="hidden" name="survey_response[nr_vehicles]" value={this.state.nrVehicles} />
-
-        <Form.Dropdown placeholder="Select from an option below" fluid selection
-                  options={ counts }
-                  onChange={this.updateNrLicenses}
-                  label={ window.__("How many people in your household have a driver's license?") }
-                  name={ 'survey_response[nr_licenses]' }/>
-
-        <input type="hidden" name="survey_response[nr_licenses]" value={this.state.nrLicenses} />
+  let childSurveys = [];
+  for (var i = 0; i < count; i++) {
+    childSurveys.push(
+      <div key={i}>
+        <ChildSurvey id={i+1} />
       </div>
-
     );
   }
-}
+
+  return (
+    <div>
+      {childSurveys}
+      <Button 
+        onClick={() => addChild(count+1)}
+        type='button'
+        className="primary"
+      >
+        { window.__('Add another child at this school') }
+      </Button>
+    </div>
+  );
+};
 
 export default ChildSurveys;

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -3,8 +3,13 @@ import ChildSurvey from './ChildSurvey';
 import { Button } from 'semantic-ui-react';
 
 const ChildSurveys = () => {
-  const [count, setStudentCount] = useState(1);
-  const [studentInfo, setStudentInfo] = useState({})
+  const [count, setStudentCount] = useState(3);
+  const [studentInfo, setStudentInfo] = useState({
+    'grade_1': "1",
+    'grade_2': "2",
+    'grade_3': "3"
+  })
+  console.log(studentInfo)
   let childSurveys = [];
   for (var i = 0; i < count; i++) {
     childSurveys.push(

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -1,49 +1,15 @@
-import React, { useReducer } from 'react';
+import React from 'react';
 import ChildSurvey from './ChildSurvey';
 import { Button } from 'semantic-ui-react';
 
-function reducer(state, action) {
-  switch(action.type) {
-    case 'updateStudent':
-      const updatedStudentInfo = state.studentInfo
-      updatedStudentInfo[`${action.id}`][`${action.property}`] = action.value;
-      return { studentInfo: updatedStudentInfo }
-    case 'addStudent':
-      const increasedStudentInfo = state.studentInfo
-      increasedStudentInfo.push({
-        grade: '',
-        to_school: '',
-        dropoff: '',
-        from_school: '',
-        pickup: ''
-      })
-      return { studentInfo: increasedStudentInfo }
-    case 'removeStudent':
-      const removedStudentInfo = state.studentInfo
-      removedStudentInfo.splice([`${action.id}`], 1)
-      return { studentInfo: removedStudentInfo}
-    default:
-      throw new Error();
-  }
-}
-
-const ChildSurveys = () => {
-  const [state, dispatch] = useReducer(reducer, {
-    studentInfo: [{
-      grade: '',
-      to_school: '',
-      dropoff: '',
-      from_school: '',
-      pickup: '',
-    }]
-  })
+const ChildSurveys = ({studentInfo, dispatch}) => {
   let childSurveys = [];
-  for (var i = 0; i < state.studentInfo.length; i++) {
+  for (var i = 0; i < studentInfo.length; i++) {
     childSurveys.push(
       <ChildSurvey
         id={i}
         key={i}
-        studentInfo={state.studentInfo}
+        studentInfo={studentInfo}
         dispatch={dispatch}
       />
     );

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -3,13 +3,16 @@ import ChildSurvey from './ChildSurvey';
 import { Button } from 'semantic-ui-react';
 
 const ChildSurveys = () => {
-  const [count, addChild] = useState(1);
+  const [count, setStudentCount] = useState(1);
 
   let childSurveys = [];
   for (var i = 0; i < count; i++) {
     childSurveys.push(
       <div key={i}>
-        <ChildSurvey id={i+1} />
+        <ChildSurvey
+          id={i+1}
+          setStudentCount
+        />
       </div>
     );
   }
@@ -18,7 +21,7 @@ const ChildSurveys = () => {
     <div>
       {childSurveys}
       <Button 
-        onClick={() => addChild(count+1)}
+        onClick={() => setStudentCount(count+1)}
         type='button'
         className="primary"
       >

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -4,7 +4,7 @@ import { Button } from 'semantic-ui-react';
 
 const ChildSurveys = () => {
   const [count, setStudentCount] = useState(1);
-
+  const [studentInfo, setStudentInfo] = useState({})
   let childSurveys = [];
   for (var i = 0; i < count; i++) {
     childSurveys.push(
@@ -13,6 +13,8 @@ const ChildSurveys = () => {
         setStudentCount={setStudentCount}
         count={count}
         key={i}
+        studentInfo={studentInfo}
+        setStudentInfo={setStudentInfo}
       />
     );
   }

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -8,12 +8,12 @@ const ChildSurveys = () => {
   let childSurveys = [];
   for (var i = 0; i < count; i++) {
     childSurveys.push(
-      <div key={i}>
-        <ChildSurvey
-          id={i+1}
-          setStudentCount
-        />
-      </div>
+      <ChildSurvey
+        id={i+1}
+        setStudentCount={setStudentCount}
+        count={count}
+        key={i}
+      />
     );
   }
 

--- a/app/javascript/components/intersecting-streets/ChildSurveys.js
+++ b/app/javascript/components/intersecting-streets/ChildSurveys.js
@@ -1,25 +1,50 @@
-import React, { useState } from 'react';
+import React, { useReducer } from 'react';
 import ChildSurvey from './ChildSurvey';
 import { Button } from 'semantic-ui-react';
 
+function reducer(state, action) {
+  switch(action.type) {
+    case 'updateStudent':
+      const updatedStudentInfo = state.studentInfo
+      updatedStudentInfo[`${action.id}`][`${action.property}`] = action.value;
+      return { studentInfo: updatedStudentInfo }
+    case 'addStudent':
+      const increasedStudentInfo = state.studentInfo
+      increasedStudentInfo.push({
+        grade: '',
+        to_school: '',
+        dropoff: '',
+        from_school: '',
+        pickup: ''
+      })
+      return { studentInfo: increasedStudentInfo }
+    case 'removeStudent':
+      const removedStudentInfo = state.studentInfo
+      removedStudentInfo.splice([`${action.id}`], 1)
+      return { studentInfo: removedStudentInfo}
+    default:
+      throw new Error();
+  }
+}
+
 const ChildSurveys = () => {
-  const [count, setStudentCount] = useState(3);
-  const [studentInfo, setStudentInfo] = useState({
-    'grade_1': "1",
-    'grade_2': "2",
-    'grade_3': "3"
+  const [state, dispatch] = useReducer(reducer, {
+    studentInfo: [{
+      grade: '',
+      to_school: '',
+      dropoff: '',
+      from_school: '',
+      pickup: '',
+    }]
   })
-  console.log(studentInfo)
   let childSurveys = [];
-  for (var i = 0; i < count; i++) {
+  for (var i = 0; i < state.studentInfo.length; i++) {
     childSurveys.push(
       <ChildSurvey
-        id={i+1}
-        setStudentCount={setStudentCount}
-        count={count}
+        id={i}
         key={i}
-        studentInfo={studentInfo}
-        setStudentInfo={setStudentInfo}
+        studentInfo={state.studentInfo}
+        dispatch={dispatch}
       />
     );
   }
@@ -27,8 +52,8 @@ const ChildSurveys = () => {
   return (
     <div>
       {childSurveys}
-      <Button 
-        onClick={() => setStudentCount(count+1)}
+      <Button
+        onClick={() => dispatch({type: 'addStudent'})}
         type='button'
         className="primary"
       >

--- a/app/javascript/components/intersecting-streets/PointsMap.js
+++ b/app/javascript/components/intersecting-streets/PointsMap.js
@@ -5,7 +5,7 @@ class PointsMap extends Component  {
   render() {
     return (
       <div className="map-container">
-        <div><label>{window.__('What is your approximate home location?')} <span className="required">({window.__('required') })</span></label></div>
+        <div className="required field"><label>{window.__('What is your approximate home location?')} <span className="required">({window.__('required') })</span></label></div>
         <div>{window.__('Please click the map at an intersection on your street, near your home:')}</div>
         <Map center={this.props.center} zoom={this.props.zoom} onClick={this.props.addCustomPoint.bind(this)}>
           <TileLayer

--- a/app/javascript/components/intersecting-streets/StreetDropdown.js
+++ b/app/javascript/components/intersecting-streets/StreetDropdown.js
@@ -107,17 +107,20 @@ class StreetDropdown extends Component {
 
   OnIntersectingPointsChange = (event, data) => {
     let chosenIndex = data.options.findIndex((el) => { return el.value === data.value });
+    this.props.dispatch({type: 'updateLatLng', value: `POINT (${this.state.points[`${chosenIndex}`]['lng']} ${this.state.points[`${chosenIndex}`]['lat']})` })
     this.setState({ selectedIntersectionIndex: chosenIndex, customPoint: null }, done => {
       this.forceUpdate();
     });
   }
 
   OnMarkerClick = (index) => {
+    this.props.dispatch({type: 'updateLatLng', value: `POINT (${this.state.points[`${index}`]['lng']} ${this.state.points[`${index}`]['lat']})` })
     this.setState({ selectedIntersectionIndex: index, customPoint: null });
   }
 
   AddCustomPoint = (loc) => {
     this.setState({ customPoint: { lat: loc.latlng.lat, lng: loc.latlng.lng } });
+    this.props.dispatch({type: 'updateLatLng', value: `POINT (${this.state.customPoint['lng']} ${this.state.customPoint['lat']})` })
   }
 
   ShowDropdowns = (event) => {
@@ -178,7 +181,6 @@ class StreetDropdown extends Component {
                         onChange={onSecondChange} />
             </div>
           </div>
-          <input type="hidden" name="survey_response[geometry]" value={`POINT (${chosenLatLng['lng']} ${chosenLatLng['lat']})`} />
         </div>
       </div>
     )


### PR DESCRIPTION
Resolves #245 (and, through some happy accident refactoring, #243)

This branch turned into a bit of an "all or nothing" scenario, so I do apologize for the lengthiness. The goal was to allow for the dynamic adding and removing of student entries on a single form submission; previously, if you clicked "Add student" by mistake, you needed to fill that out or reload the entire page. This required tracking the number of students in local state.

The big takeaways here are:

- Rewriting `ChildSurvey` and `ChildSurveys` as functional components; perhaps not completely necessary, but as React leans further away from class-based components, now seemed as good a time as ever to do some refactoring. I had intended to refactor `StreetDropdown` and `PointsMap` as well, but given the size and complexity of those components I think that's a job for another PR. I do pass the reducer down `StreetDropdown` in order to save the home address lat/lng in `App`'s state, though.
- Keep track of all form state in `App.jsx` and update values through a reducer passed down to child components via props. This was my first time using `useReducer` so happy to take any notes or pointers you may have, but I am a fan. As you can probably tell in commit [9ccb8b](https://github.com/MAPC/myschoolcommute2/commit/9ccb8b3b17d79a970d35f30853978ee9fa23617c), my pre-reducer logic was not exactly beautiful.
- Update validation logic to check for matches between state values and visible form fields instead of values in hidden `input` fields. I use a couple of Regex's (Regei?) to check for state in a particular index of the `studentInfo` state array.
- The first student entry is written into the database under index 0 (so `grade_0` and `to_school_0`) instead of 1.