### PR TITLE
Allow mailers on staging and prod

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -19,6 +19,7 @@ Rails.application.configure do
     api_key: Rails.application.secrets.mailgun_api_key,
     domain: 'mailgun2.mapc.org'
   }
+  config.action_mailer.default_url_options = { host: 'masaferoutessurvey.org' }
 
 
   # Enable Rack::Cache to put a simple HTTP cache in front of your application

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -40,6 +40,7 @@ Rails.application.configure do
     api_key: Rails.application.secrets.mailgun_api_key,
     domain: 'mailgun2.mapc.org'
   }
+  config.action_mailer.default_url_options = { host: 'staging.masaferoutessurvey.org' }
 
   # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
 


### PR DESCRIPTION
From StackOverflow question, based on error raised in Sentry: https://stackoverflow.com/questions/7219732/rails-missing-host-to-link-to-please-provide-host-parameter-or-set-default-ur

Resolves #250 

## Description
We had not set `config.action_mailer.default_url_options` for staging or production (on develop, they're set to `{ host: 'localhost', port: 3000 }`). This meant that when we tried to send Rails emails, most notably the "Forgot password?" mailer, links did not work. This commit adds in rules for both staging and production.

That said, this is based on my understanding of Rails as explained by a few Stack Overflow posts. Since this project has been around for awhile, I was wondering if you had any insight as to how the mailers worked previously? Did we just start hitting errors due to an update in Rails?