### PR TITLE
Add policy and additional response formats for survey responses download

### DIFF
--- a/app/controllers/survey_responses_controller.rb
+++ b/app/controllers/survey_responses_controller.rb
@@ -3,8 +3,11 @@ class SurveyResponsesController < ApplicationController
   # GET /survey_responses
   # GET /survey_responses.json
   def index
+    authorize SurveyResponse
     respond_to do |format|
       format.csv { send_data SurveyResponse.to_csv }
+      format.html { redirect_to '/', notice: 'This page is not available. Please contact an administrator for assistance.' }
+      format.json { redirect_to '/', notice: 'This resource is not available. Please contact an administrator for assistance.' }
     end
   end
 
@@ -20,7 +23,6 @@ class SurveyResponsesController < ApplicationController
       @survey_response = SurveyResponse.new(school: School.find(params[:school_id]))
       @school = School.find(params[:school_id])
       @all_surveys = Survey.select(:id).where(:school_id => @school.id).all
-      # binding.pry
     else
       @survey_response = SurveyResponse.new
     end

--- a/app/policies/survey_response_policy.rb
+++ b/app/policies/survey_response_policy.rb
@@ -1,4 +1,8 @@
 class SurveyResponsePolicy < ApplicationPolicy
+  def index?
+    user != nil and (user.is_admin?)
+  end
+
   def new?
     user != nil and (user.is_admin? or user.is_district?)
   end


### PR DESCRIPTION
## Description
In response to Sentry issue 2129581754, which reported an `ActionController::UnknownFormat` on `SurveyResponsesController#index`. The route `/survey_responses` should only be accessible to admins, and in particular it is a download link to `survey_responses.csv`. This commit handles both the HTML and JSON versions of the same request (perhaps not in the most elegant way; would happily welcome refactoring suggestions) and adjusts the Survey Responses policy so that only Admin users can successfully access the route and download the CSV.