### PR TITLE
Sentry/2078975796 wrong number arguments

### DIFF
--- a/app/assets/javascripts/new_school.js
+++ b/app/assets/javascripts/new_school.js
@@ -2,11 +2,9 @@
  var clickMarker
  var latlong
 
- L.tileLayer('https://api.tiles.mapbox.com/v4/{id}/{z}/{x}/{y}.png?access_token={accessToken}', {
-     attribution: 'Map data &copy; <a href="http://openstreetmap.org">OpenStreetMap</a> contributors, <a href="http://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, Imagery © <a href="http://mapbox.com">Mapbox</a>',
+ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+  attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors',
      maxZoom: 18,
-     id: 'mapbox.streets',
-     accessToken: 'pk.eyJ1IjoibXphZ2FqYSIsImEiOiJ5N0Y3Z3pVIn0.Wqu2VeG4ycaw0nPrwy0-sA'
  }).addTo(mymap);
 
  function onMapClick(e) {

--- a/app/dashboards/school_dashboard.rb
+++ b/app/dashboards/school_dashboard.rb
@@ -63,8 +63,8 @@ class SchoolDashboard < Administrate::BaseDashboard
     # :shed_10,
     # :shed_15,
     # :shed_20,
-    :created_at,
-    :updated_at,
+    # :created_at,
+    # :updated_at,
     # :muni_id,
   ].freeze
 

--- a/app/models/school.rb
+++ b/app/models/school.rb
@@ -134,6 +134,10 @@ class School < ActiveRecord::Base
     # Ugly hack to transform SRID 4326 input from leaflet to the expected SRID of 26986
     point = RGeo::Cartesian.factory(srid: 4326, proj4: '+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs').point(self.geometry.x, self.geometry.y)
     ma_factory = RGeo::Cartesian.factory(srid: 26986, proj4: '+proj=lcc +lat_1=42.68333333333333 +lat_2=41.71666666666667 +lat_0=41 +lon_0=-71.5 +x_0=200000 +y_0=750000 +ellps=GRS80 +datum=NAD83 +units=m +no_defs')
-    self.geometry = RGeo::Feature.cast(point, factory: ma_factory, project: true)
+    begin
+      self.geometry = RGeo::Feature.cast(point, factory: ma_factory, project: true)
+    rescue
+      self.geometry
+    end
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200804175633) do
+ActiveRecord::Schema.define(version: 20210105211736) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
## Description
Resolves both Sentry issue 2078975796 (`ArgumentError` when updating a School in the admin panel) and Sentry issue 2079063980 (`undefined method 'created_at'` when viewing an individual school's Show page in the admin panel).

### 2078975796 (`ArgumentError` on `Admin::SchoolsController#update`)
Error:
```
wrong number of arguments (given 0, expected 2+)
# Error on line 137 of app/models/school.rb:
# self.geometry = RGeo::Feature.cast(point, factory: ma_factory, project: true)
```

This seems to be an error in translating between SRIDs, and how RGeo handles that when "receiving" inputs in SRID 26986 (how it's stored in Postgres) as opposed to SRID 4326 (how coordinates are placed when interacting with the Leaflet map). I put "receiving" in quotation marks because this transformation occurred whether or not there were new coordinates to translate; if there weren't (Say, the user wanted to update the school's name only) then RGeo threw an `ArgumentError`.

In this approach, I try to perform the transformation as it currently is written; if we hit an error, the geometry is set to itself.

Another way to approach this may be to check the SRID of the incoming `geometry` property and only apply the transformation to geometries of the proper shape. However, the [docs for a CAPIPointImpl](https://www.rubydoc.info/github/rgeo/rgeo/RGeo/Geos/CAPIPointImpl) (the class we're using to define `geometry`) don't provide much information about how to get the SRID.

### 2079063980 (`undefined method 'created_at'` on `Admin::SchoolsController#show`)

Usually I would have created a new branch/PR for a separate Sentry issue, but I incidentally had to resolve this before being able to investigate the `ArgumentError`. It's also a very minor fix: we do not currently have `created_at` or `updated_at` attributes for Schools, so an error would throw whenever Administrate tried to display them on a School's show page. Removing them from the array of `SHOW_PAGE_ATTRIBUTES` got us around this error.

We have these two properties on most other models, and could imagine it being useful at some point to write a migration and add them in (I tried this, actually, but ran into problems when re-seeding the database after I made an unrelated mistake).

### Side effects
Unrelated to both issues (but related to the School update form), I noticed that the previous Mapbox basemap was no longer appearing. Rather than dig into access token debugging, I simply replaced that basemap with the same OpenStreetMaps basemap used in the surveys themselves.
